### PR TITLE
ghc 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/haskell-CI/haskell-ci
+# For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.16.4
+# version: 0.17.20231012
 #
-# REGENDATA ("0.16.4",["github","agda2lagda.cabal"])
+# REGENDATA ("0.17.20231012",["github","agda2lagda.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,14 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.6.3
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.7
+            compilerKind: ghc
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -91,8 +96,9 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
@@ -106,10 +112,12 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
           echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
           echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
@@ -167,7 +175,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -17,20 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         # Note: check release logic below when changing the matrix!
-        ghc: [9.6.2, 9.4.5, 9.2.8, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc: ['9.6', '9.4', '9.2.8', '9.0.2', '8.10.7', '8.8.4', '8.6.5', '8.4.4', '8.2.2', '8.0.2']
         os: [ubuntu-latest]
         include:
           - os: macOS-latest
-            ghc: 9.6.2
+            ghc: '9.6'
           - os: windows-latest
-            ghc: 9.6.2
-
-    ## Cannot define STACK_FLAGS here since we depend on GHC_VERSION
-    # env:
-    #   STACK_FLAGS: --stack-yaml stack-${{ matrix.ghc }}.yaml --no-terminal --color always --system-ghc
-    #   # STACK_BUILD: stack build ${{ STACK_FLAGS }}  ## invalid
-    #   # STACK_BUILD: stack build ${{ env.STACK_FLAGS }}  ## also invalid
-    #   STACK_BUILD: stack build --stack-yaml stack-${{ matrix.ghc }}.yaml --no-terminal --color always --system-ghc
+            ghc: '9.6'
+    env:
+      STACK_FLAGS: --stack-yaml stack-${{ matrix.ghc }}.yaml --no-terminal --color always --system-ghc
+      STACK_YAML: stack-${{ matrix.ghc }}.yaml
+      # STACK_BUILD: stack build ${{ STACK_FLAGS }}  ## invalid
+      # STACK_BUILD: stack build ${{ env.STACK_FLAGS }}  ## also invalid
 
     # Needed for Windows to make piping (... >> ...) and evaluation ( $(...) ) work.
     defaults:
@@ -38,7 +36,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Haskell
         uses: haskell-actions/setup@v2
@@ -65,12 +63,13 @@ jobs:
           echo "stack-root    = ${{ steps.haskell-setup.outputs.stack-root    }}"
           GHC_VERSION=${{ steps.haskell-setup.outputs.ghc-version }}
           STACK_VERSION=${{ steps.haskell-setup.outputs.stack-version }}
-          STACK_YAML=stack-${GHC_VERSION}.yaml
-          STACK_FLAGS="--stack-yaml ${STACK_YAML} --system-ghc --no-terminal --color always"
           echo "GHC_VERSION=${GHC_VERSION}"     >> "${GITHUB_ENV}"
           echo "STACK_VERSION=${STACK_VERSION}" >> "${GITHUB_ENV}"
-          echo "STACK_YAML=${STACK_YAML}"       >> "${GITHUB_ENV}"
-          echo "STACK_FLAGS=${STACK_FLAGS}"     >> "${GITHUB_ENV}"
+
+        # STACK_YAML=stack-${GHC_VERSION}.yaml
+        # STACK_FLAGS="--stack-yaml ${STACK_YAML} --system-ghc --no-terminal --color always"
+        # echo "STACK_YAML=${STACK_YAML}"       >> "${GITHUB_ENV}"
+        # echo "STACK_FLAGS=${STACK_FLAGS}"     >> "${GITHUB_ENV}"
 
       - name: Cache dependencies
         # if:   runner.os == 'Linux'
@@ -88,17 +87,6 @@ jobs:
             # https://github.com/commercialhaskell/stack/issues/5866
             # Don't restore cached builds from older GHC versions:
             # ${{ runner.os }}-stack-
-        ## DOESN'T WORK:
-        # # For brevity of notation (rather than for using the environment variable), let
-        # #   env.stack-root = steps.haskell-setup.outputs.stack-root
-        # env:
-        #   stack-root: ${{ steps.haskell-setup.outputs.stack-root }}
-        # with:
-        #   path: ${{ env.stack-root }}
-        #   # A unique cache is used for each stack.yaml.
-        #   key: ${{ runner.os }}-${{ env.stack-root }}-${{ hashFiles(format('stack-{0}.yaml', matrix.ghc)) }}
-          # runner.os is explained here:
-          # https://stackoverflow.com/questions/57946173/github-actions-run-step-on-specific-os
 
       - name: Build dependencies.
         # run: stack build --stack-yaml stack-${{ matrix.ghc }}.yaml --no-terminal --color always --system-ghc --only-dependencies
@@ -129,7 +117,7 @@ jobs:
         # Conditional to ensure this deployment is only run once per action.
         if: >-
           startsWith(github.ref, 'refs/tags/v')
-          && matrix.ghc == '9.6.2'
+          && matrix.ghc == '9.6'
         run: |
           DIST_TGZ=$(cabal sdist | tail -1)
           echo "DIST_TGZ=${DIST_TGZ}" >> "${GITHUB_ENV}"
@@ -137,7 +125,7 @@ jobs:
       - name: Source tarball release.
         if: >-
           startsWith(github.ref, 'refs/tags/v')
-          && matrix.ghc == '9.6.2'
+          && matrix.ghc == '9.6'
         uses: softprops/action-gh-release@v1
         with:
           draft: true

--- a/agda2lagda.cabal
+++ b/agda2lagda.cabal
@@ -32,8 +32,9 @@ extra-source-files:
   test/golden/*.lagda.tex
 
 tested-with:
-  GHC == 9.6.2
-  GHC == 9.4.5
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7

--- a/stack-9.4.4.yaml
+++ b/stack-9.4.4.yaml
@@ -1,3 +1,0 @@
-resolver: nightly-2023-03-24
-compiler: ghc-9.4.4
-compiler-check: match-exact

--- a/stack-9.4.5.yaml
+++ b/stack-9.4.5.yaml
@@ -1,3 +1,0 @@
-resolver: lts-21.0
-compiler: ghc-9.4.5
-compiler-check: match-exact

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -1,0 +1,1 @@
+resolver: lts-21.15

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -1,3 +1,0 @@
-resolver: nightly-2023-06-22
-compiler: ghc-9.6.2
-compiler-check: match-exact

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,0 +1,1 @@
+resolver: nightly-2023-10-09


### PR DESCRIPTION
- Bump Haskell CI to GHC 9.8.1
- Stack workflow: move to `stack-x.y.yaml` files for GHCs 9.4 and 9.6
